### PR TITLE
feat: add blockConfig param to @icedesign/template-rax

### DIFF
--- a/packages/template-rax/package.json
+++ b/packages/template-rax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/template-rax",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Rax 物料模板",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/template-rax/template/block/package.json.ejs
+++ b/packages/template-rax/template/block/package.json.ejs
@@ -30,5 +30,10 @@
     "rax": "^1.1.0",
     "rax-test-renderer": "^1.0.0",
     "typescript": "^3.7.5"
-  }
+  },
+  "blockConfig": {
+    "name": "<%= name %>",
+    "title": "<%= title %>",
+    "category": "<%= category %>"
+  },
 }


### PR DESCRIPTION
背景：

创建 rax 区块时， 区块的 package.json 中没有 `blockConfig` 字段
