### PR TITLE
fix: add docusaurus plugin in workspace sub package

### DIFF
--- a/packages/template-pkg-node/CHANGELOG.md
+++ b/packages/template-pkg-node/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.10
+
+- [fix] add docusaurus plugin in sub package template
+
 ## 1.0.9
 
 - [chore] update docs link

--- a/packages/template-pkg-node/package.json
+++ b/packages/template-pkg-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/template-pkg-node",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "files": [
     "template"
   ],

--- a/packages/template-pkg-node/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-node/template/component/build.config.mts.ejs
@@ -5,7 +5,9 @@ export default defineConfig({
   transform: {
     formats: ['es2017'],
   },
+<% if (!locals.workspace) { _%>
   plugins: [
     '@ice/pkg-plugin-docusaurus',
   ],
+<% } _%>
 });

--- a/packages/template-pkg-node/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-node/template/component/build.config.mts.ejs
@@ -5,4 +5,7 @@ export default defineConfig({
   transform: {
     formats: ['es2017'],
   },
+  plugins: [
+    '@ice/pkg-plugin-docusaurus',
+  ],
 });

--- a/packages/template-pkg-node/template/component/docs/index.md.ejs
+++ b/packages/template-pkg-node/template/component/docs/index.md.ejs
@@ -1,0 +1,8 @@
+---
+sidebar_label: 首页
+sidebar_position: 0
+---
+
+import Readme from '../README.md';
+
+<Readme />

--- a/packages/template-pkg-node/template/component/package.json.ejs
+++ b/packages/template-pkg-node/template/component/package.json.ejs
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@applint/spec": "^1.2.3",
     "@ice/pkg": "^1.0.0",
+    "@ice/pkg-plugin-docusaurus": "^1.0.0",
     "eslint": "^8.0.0"
   },
   "publishConfig": {

--- a/packages/template-pkg-node/template/component/package.json.ejs
+++ b/packages/template-pkg-node/template/component/package.json.ejs
@@ -45,7 +45,9 @@
   "devDependencies": {
     "@applint/spec": "^1.2.3",
     "@ice/pkg": "^1.0.0",
+<% if (!locals.workspace) { _%>
     "@ice/pkg-plugin-docusaurus": "^1.0.0",
+<% } _%>
     "eslint": "^8.0.0"
   },
   "publishConfig": {

--- a/packages/template-pkg-rax/CHANGELOG.md
+++ b/packages/template-pkg-rax/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.12
+
+- [fix] add docusaurus plugin in sub package template
+
 ## 1.0.11
 
 - [chore] update docs link

--- a/packages/template-pkg-rax/package.json
+++ b/packages/template-pkg-rax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/template-pkg-rax",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "files": [
     "template"
   ],

--- a/packages/template-pkg-rax/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-rax/template/component/build.config.mts.ejs
@@ -3,7 +3,9 @@ import { defineConfig } from '@ice/pkg';
 // https://pkg.ice.work/reference/config/
 export default defineConfig({
   plugins: [
+<% if (!locals.workspace) { _%>
     '@ice/pkg-plugin-docusaurus',
+<% } _%>
     '@ice/pkg-plugin-rax-component',
   ],
 });

--- a/packages/template-pkg-rax/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-rax/template/component/build.config.mts.ejs
@@ -4,6 +4,6 @@ import { defineConfig } from '@ice/pkg';
 export default defineConfig({
   plugins: [
     '@ice/pkg-plugin-docusaurus',
-    '@ice/pkg-plugin-rax-component'
+    '@ice/pkg-plugin-rax-component',
   ],
 });

--- a/packages/template-pkg-rax/template/component/package.json.ejs
+++ b/packages/template-pkg-rax/template/component/package.json.ejs
@@ -50,7 +50,9 @@
   "devDependencies": {
     "@applint/spec": "^1.2.3",
     "@ice/pkg": "^1.0.0",
+<% if (!locals.workspace) { _%>
     "@ice/pkg-plugin-docusaurus": "^1.0.0",
+<% } _%>
     "@ice/pkg-plugin-rax-component": "^1.0.0",
     "eslint": "^8.0.0",
     "@types/rax": "^1.0.0",

--- a/packages/template-pkg-react/CHANGELOG.md
+++ b/packages/template-pkg-react/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.12
+
+- [fix] add docusaurus plugin in sub package template
+
 ## 1.2.11
 
 - [chore] update docs link

--- a/packages/template-pkg-react/package.json
+++ b/packages/template-pkg-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/template-pkg-react",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "files": [
     "template"
   ],

--- a/packages/template-pkg-react/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-react/template/component/build.config.mts.ejs
@@ -2,7 +2,9 @@ import { defineConfig } from '@ice/pkg';
 
 // https://pkg.ice.work/reference/config/
 export default defineConfig({
+<% if (!locals.workspace) { _%>
   plugins: [
     '@ice/pkg-plugin-docusaurus',
   ],
+<% } _%>
 });

--- a/packages/template-pkg-react/template/component/package.json.ejs
+++ b/packages/template-pkg-react/template/component/package.json.ejs
@@ -51,7 +51,9 @@
   "devDependencies": {
     "@applint/spec": "^1.2.3",
     "@ice/pkg": "^1.0.0",
+<% if (!locals.workspace) { _%>
     "@ice/pkg-plugin-docusaurus": "^1.0.0",
+<% } _%>
     "eslint": "^8.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/packages/template-pkg-web/CHANGELOG.md
+++ b/packages/template-pkg-web/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.11
+
+- [fix] add docusaurus plugin in sub package template
+
 ## 1.0.10
 
 - [chore] update docs link

--- a/packages/template-pkg-web/package.json
+++ b/packages/template-pkg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ice/template-pkg-web",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "files": [
     "template"
   ],

--- a/packages/template-pkg-web/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-web/template/component/build.config.mts.ejs
@@ -2,7 +2,9 @@ import { defineConfig } from '@ice/pkg';
 
 // https://pkg.ice.work/reference/config/
 export default defineConfig({
+<% if (!locals.workspace) { _%>
   plugins: [
     '@ice/pkg-plugin-docusaurus',
   ],
+<% } _%>
 });

--- a/packages/template-pkg-web/template/component/build.config.mts.ejs
+++ b/packages/template-pkg-web/template/component/build.config.mts.ejs
@@ -1,4 +1,8 @@
 import { defineConfig } from '@ice/pkg';
 
 // https://pkg.ice.work/reference/config/
-export default defineConfig({});
+export default defineConfig({
+  plugins: [
+    '@ice/pkg-plugin-docusaurus',
+  ],
+});

--- a/packages/template-pkg-web/template/component/docs/index.md.ejs
+++ b/packages/template-pkg-web/template/component/docs/index.md.ejs
@@ -1,0 +1,8 @@
+---
+sidebar_label: 首页
+sidebar_position: 0
+---
+
+import Readme from '../README.md';
+
+<Readme />

--- a/packages/template-pkg-web/template/component/package.json.ejs
+++ b/packages/template-pkg-web/template/component/package.json.ejs
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@applint/spec": "^1.2.3",
     "@ice/pkg": "^1.0.0",
+    "@ice/pkg-plugin-docusaurus": "^1.0.0",
     "eslint": "^8.0.0",
     "stylelint": "^15.0.0"
   },

--- a/packages/template-pkg-web/template/component/package.json.ejs
+++ b/packages/template-pkg-web/template/component/package.json.ejs
@@ -48,7 +48,9 @@
   "devDependencies": {
     "@applint/spec": "^1.2.3",
     "@ice/pkg": "^1.0.0",
+<% if (!locals.workspace) { _%>
     "@ice/pkg-plugin-docusaurus": "^1.0.0",
+<% } _%>
     "eslint": "^8.0.0",
     "stylelint": "^15.0.0"
   },


### PR DESCRIPTION
使用 `npm init @ice/pkg -w packages/lib` 的时候，不应该新增 docusaurus 插件